### PR TITLE
README: Add trakt-java third-party library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All of the libraries listed below are user contributed. If you find a bug or mis
 |              | TraktSharp     | https://github.com/wwarby/TraktSharp           |
 | C++          | libtraqt       | https://github.com/RobertMe/libtraqt           |
 | Clojure      | clj-trakt      | https://github.com/niamu/clj-trakt             |
+| Java         | trakt-java     | https://github.com/UweTrottmann/trakt-java     |
 | Node.js      | Trakt.tv       | https://github.com/vankasteelj/trakt.tv        |
 |              | TraktApi2      | https://github.com/PatrickE94/traktapi2        |
 | Python       | trakt.py       | https://github.com/fuzeman/trakt.py            |


### PR DESCRIPTION
Shamelessly plugging my own lib.

https://github.com/UweTrottmann/trakt-java