### PR TITLE
Add library MoviebaseApp/trakt-api to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ All of the libraries listed below are user contributed. If you find a bug or mis
 | C++          | libtraqt       | https://github.com/RobertMe/libtraqt           |
 | Clojure      | clj-trakt      | https://github.com/niamu/clj-trakt             |
 | Java         | trakt-java     | https://github.com/UweTrottmann/trakt-java     |
+| Kotlin       | trakt-api      | https://github.com/MoviebaseApp/trakt-api      |
 | Node.js      | Trakt.tv       | https://github.com/vankasteelj/trakt.tv        |
 |              | TraktApi2      | https://github.com/PatrickE94/traktapi2        |
 | Python       | trakt.py       | https://github.com/fuzeman/trakt.py            |


### PR DESCRIPTION
Add the new Kotlin library to the README.

https://github.com/MoviebaseApp/trakt-api